### PR TITLE
feat: ログアウト導線をBottomNav 3画面で統一 (#72)

### DIFF
--- a/app/recipes/page.tsx
+++ b/app/recipes/page.tsx
@@ -1,16 +1,19 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
 import BottomNav from '@/components/BottomNav';
+import ScreenHeader from '@/components/ScreenHeader';
 import RecipeCard from '@/components/RecipeCard';
 import RecipeCreateModal from '@/components/RecipeCreateModal';
 import { Recipe, RecipeListItem, RecipeSourceType } from '@/types';
-import { getAuth, onAuthStateChanged, User } from 'firebase/auth';
-import '@/lib/firebase';
 
 type FilterType = 'all' | RecipeSourceType;
 
 export default function RecipesPage() {
+  const { user, loading: authLoading } = useAuth();
+  const router = useRouter();
   const [recipes, setRecipes] = useState<RecipeListItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -23,15 +26,12 @@ export default function RecipesPage() {
   const [selectedRecipe, setSelectedRecipe] = useState<Recipe | null>(null);
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
-  const [user, setUser] = useState<User | null>(null);
 
   useEffect(() => {
-    const auth = getAuth();
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      setUser(user);
-    });
-    return () => unsubscribe();
-  }, []);
+    if (!authLoading && !user) {
+      router.push('/auth/signin');
+    }
+  }, [authLoading, user, router]);
 
   const fetchRecipes = useCallback(async () => {
     if (!user) return;
@@ -206,108 +206,100 @@ export default function RecipesPage() {
     }
   };
 
+  if (authLoading) {
+    return <div className="flex items-center justify-center min-h-screen">Loading...</div>;
+  }
+
   if (!user) {
-    return (
-      <main className="min-h-screen bg-gray-50 pb-20">
-        <div className="p-6">
-          <h1 className="text-2xl font-bold mb-6">レシピ</h1>
-          <div className="text-center py-12 text-gray-500">
-            ログインしてください
-          </div>
-        </div>
-        <BottomNav />
-      </main>
-    );
+    return null;
   }
 
   return (
     <main className="min-h-screen bg-gray-50 pb-20">
-      {/* ヘッダー */}
-      <div className="sticky top-0 bg-white/95 backdrop-blur-sm border-b border-gray-100 z-10">
-        <div className="p-4">
-          <div className="flex items-center justify-between mb-4">
-            <h1 className="text-2xl font-bold">レシピ</h1>
+      <ScreenHeader
+        title="レシピ"
+        rightAction={
+          <button
+            onClick={handleGenerateAIRecipe}
+            disabled={isGenerating}
+            aria-busy={isGenerating}
+            className={`inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+              isGenerating
+                ? 'cursor-not-allowed bg-gray-200 text-gray-500'
+                : 'bg-gray-900 text-white hover:bg-gray-800'
+            }`}
+          >
+            {isGenerating ? (
+              <>
+                <span className="inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/70 border-t-transparent" />
+                生成中
+              </>
+            ) : (
+              <>
+                <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 6v6l4 2m6-2a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                AI生成
+              </>
+            )}
+          </button>
+        }
+      />
+      <div className="border-b border-gray-100 bg-white px-4 py-4">
+        {/* 検索バー */}
+        <div className="relative mb-4">
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="レシピを検索..."
+            className="w-full rounded-full border border-gray-200 py-2 pl-10 pr-4 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
+          />
+          <svg
+            className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+        </div>
+
+        {/* フィルター */}
+        <div className="flex gap-2">
+          {(['all', 'user_created', 'ai_generated'] as FilterType[]).map((f) => (
             <button
-              onClick={handleGenerateAIRecipe}
-              disabled={isGenerating}
-              aria-busy={isGenerating}
-              className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors ${
-                isGenerating
-                  ? 'bg-gray-200 text-gray-500 cursor-not-allowed'
-                  : 'bg-gray-900 text-white hover:bg-gray-800'
+              key={f}
+              onClick={() => setFilter(f)}
+              className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                filter === f
+                  ? 'bg-gray-900 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
               }`}
             >
-              {isGenerating ? (
-                <>
-                  <span className="inline-block w-4 h-4 border-2 border-white/70 border-t-transparent rounded-full animate-spin" />
-                  生成中...
-                </>
-              ) : (
-                <>
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M12 6v6l4 2m6-2a9 9 0 11-18 0 9 9 0 0118 0z"
-                    />
-                  </svg>
-                  AIで生成
-                </>
-              )}
+              {f === 'all' ? 'すべて' : f === 'user_created' ? '手入力' : 'AI生成'}
             </button>
-          </div>
-
-          {/* 検索バー */}
-          <div className="relative mb-4">
-            <input
-              type="text"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="レシピを検索..."
-              className="w-full pl-10 pr-4 py-2 border border-gray-200 rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
-            />
-            <svg
-              className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-              />
-            </svg>
-          </div>
-
-          {/* フィルター */}
-          <div className="flex gap-2">
-            {(['all', 'user_created', 'ai_generated'] as FilterType[]).map((f) => (
-              <button
-                key={f}
-                onClick={() => setFilter(f)}
-                className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
-                  filter === f
-                    ? 'bg-gray-900 text-white'
-                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                }`}
-              >
-                {f === 'all' ? 'すべて' : f === 'user_created' ? '手入力' : 'AI生成'}
-              </button>
-            ))}
-          </div>
-          {(generateError || generateSuccess) && (
-            <div className="mt-3 text-sm">
-              {generateError ? (
-                <p className="text-red-600">{generateError}</p>
-              ) : (
-                <p className="text-emerald-600">{generateSuccess}</p>
-              )}
-            </div>
-          )}
+          ))}
         </div>
+        {(generateError || generateSuccess) && (
+          <div className="mt-3 text-sm">
+            {generateError ? (
+              <p className="text-red-600">{generateError}</p>
+            ) : (
+              <p className="text-emerald-600">{generateSuccess}</p>
+            )}
+          </div>
+        )}
       </div>
 
       {/* レシピ一覧 */}


### PR DESCRIPTION
## 概要
- Issue #72 対応として、ログアウト導線を BottomNav の3画面で統一

## 変更内容
- /recipes を useAuth ベースに統一
- /recipes で未認証時に /auth/signin へ遷移
- /recipes ヘッダーを ScreenHeader に統一し、右上ログアウト導線を追加

## テスト
- npm run lint
- /notifications, /inventory, /recipes でログアウトボタンが表示されること
- ログアウト後に /auth/signin へ遷移すること
- ログアウト後に /recipes 直接アクセスで /auth/signin へ遷移すること

Closes #72