### PR TITLE
Add Terraform CI/CD workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,14 @@ env:
   INSTANCE_CONN: syufy-485423:asia-northeast1:mini-hackathon-db
 
 jobs:
+  terraform:
+    name: Terraform Apply
+    uses: ./.github/workflows/terraform-apply.yml
+    secrets: inherit
+
   deploy:
     name: Deploy to Cloud Run
+    needs: terraform
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,58 @@
+name: Terraform Apply
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: terraform-apply-production
+  cancel-in-progress: false
+
+env:
+  TF_WORKING_DIR: cloud
+
+jobs:
+  apply:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+    environment: production
+    defaults:
+      run:
+        working-directory: ${{ env.TF_WORKING_DIR }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.5"
+
+      - name: Terraform Init
+        run: terraform init -input=false
+
+      - name: Terraform Plan
+        run: terraform plan -no-color -input=false -out=tfplan
+        env:
+          TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
+          TF_VAR_firebase_client_email: ${{ secrets.FIREBASE_CLIENT_EMAIL }}
+          TF_VAR_firebase_private_key: ${{ secrets.FIREBASE_PRIVATE_KEY }}
+          TF_VAR_firebase_api_key: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
+          TF_VAR_firebase_auth_domain: ${{ secrets.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}
+          TF_VAR_firebase_project_id: ${{ secrets.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}
+          TF_VAR_firebase_storage_bucket: ${{ secrets.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET }}
+          TF_VAR_firebase_messaging_sender_id: ${{ secrets.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID }}
+          TF_VAR_firebase_app_id: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
+          TF_VAR_gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          TF_VAR_notify_secret: ${{ secrets.NOTIFY_SECRET }}
+
+      - name: Terraform Apply
+        run: terraform apply -input=false -auto-approve tfplan

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,128 @@
+name: Terraform Plan
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "cloud/**"
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: terraform-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TF_WORKING_DIR: cloud
+
+jobs:
+  plan:
+    name: Terraform Plan
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.TF_WORKING_DIR }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.5"
+
+      - name: Terraform Format Check
+        id: fmt
+        run: terraform fmt -check -recursive
+        continue-on-error: true
+
+      - name: Terraform Init
+        id: init
+        run: terraform init -input=false
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color -input=false
+        continue-on-error: true
+        env:
+          TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
+          TF_VAR_firebase_client_email: ${{ secrets.FIREBASE_CLIENT_EMAIL }}
+          TF_VAR_firebase_private_key: ${{ secrets.FIREBASE_PRIVATE_KEY }}
+          TF_VAR_firebase_api_key: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
+          TF_VAR_firebase_auth_domain: ${{ secrets.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}
+          TF_VAR_firebase_project_id: ${{ secrets.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}
+          TF_VAR_firebase_storage_bucket: ${{ secrets.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET }}
+          TF_VAR_firebase_messaging_sender_id: ${{ secrets.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID }}
+          TF_VAR_firebase_app_id: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
+          TF_VAR_gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          TF_VAR_notify_secret: ${{ secrets.NOTIFY_SECRET }}
+
+      - name: Comment Plan on PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fmt = '${{ steps.fmt.outcome }}';
+            const init = '${{ steps.init.outcome }}';
+            const validate = '${{ steps.validate.outcome }}';
+            const plan = '${{ steps.plan.outcome }}';
+
+            const planOutput = `${{ steps.plan.outputs.stdout }}`.slice(0, 60000);
+
+            const body = `### Terraform Plan Result
+            | Step | Status |
+            |------|--------|
+            | Format | ${fmt === 'success' ? '✅' : '⚠️'} |
+            | Init | ${init === 'success' ? '✅' : '❌'} |
+            | Validate | ${validate === 'success' ? '✅' : '❌'} |
+            | Plan | ${plan === 'success' ? '✅' : '❌'} |
+
+            <details><summary>Plan Output</summary>
+
+            \`\`\`
+            ${planOutput}
+            \`\`\`
+
+            </details>
+
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('### Terraform Plan Result')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail if plan failed
+        if: steps.plan.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
## Summary
- Terraform CI/CD ワークフローを追加し、インフラ管理をGitHub Actionsに移行
- CI: PR時に `terraform plan` で差分確認
- CD: リリース時に `terraform apply` でインフラ適用

## Changes
### 新規ワークフロー
- **terraform-plan.yml**: PR時にTerraformのformat/init/validate/planを実行し、結果をPRコメントに表示
- **terraform-apply.yml**: `workflow_call`/`workflow_dispatch`で呼び出し可能。Terraform applyを実行

### 既存ワークフロー更新
- **deploy.yml**: Terraform Applyを先に実行し、その後にCloud Runデプロイを実行するように変更

## Flow
```
release.yml: CI → Deploy
                    ├─ Terraform Apply (インフラ適用)
                    └─ Cloud Run Deploy (アプリデプロイ)
```

## 前提条件
- 既存のWorkload Identity Federationを利用
- サービスアカウントにTerraform管理リソースへの権限が必要
- GitHub Secretsは既存の`deploy.yml`と同じものを使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)